### PR TITLE
Support XDJ-AZ four deck mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log follows the conventions of
 ### Added
 
 - The ability to provide limited features with the Opus Quad, even though that hardware does not really support the Pro DJ Link protocol, by leveraging its ability to work with rekordbox lighting. Thanks to [@cprepos](https://github.com/cprepos) for doing most of this work! Note that because the Opus Quad does not send beat packets, we might be up to 200ms out of sync with beats, since that is how often status packets arrive.
+- Added compatibility with the XDJ-AZ in four deck mode, which uses standard player numbers but requires the same proxying approach as the Opus Quad.
 - Support for the three-band waveform style introduced with the CDJ-3000.
 - The ability to proxy metadata from mounted archive files corresponding to USB media mounted in the Opus Quad, which cannot itself provide that information.
 - We now know how to interpret the byte within device announcement packets that report the number of peer devices seen by that device. The `DeviceAnnouncement` class now provides access to this information.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ releases of hardware or even firmware updates from Pioneer.
 > and nxs2 gear, and release 7.3.0 supports CDJ-3000 features. It
 > works fairly well (with less information available) with older
 > CDJ-2000s. It has also been reported to work with XDJ-1000 gear, and
-> (starting with version 0.6.0) with the XDJ-XZ as well. If you can
+> (starting with version 0.6.0) with the XDJ-XZ as well. Support for the XDJ-AZ
+> operating in four deck mode has now been added too. If you can
 > try it with anything else, *please* let us know what you learn in
 > [Beat Link Trigger's Zulip chat
 > stream](https://deep-symmetry.zulipchat.com/#narrow/stream/275322-beat-link-trigger),

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
@@ -56,7 +56,7 @@ public class DeviceAnnouncement {
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         timestamp = System.currentTimeMillis();
         name = new String(packetBytes, 0x0c, 20).trim();
-        isOpusQuad = name.equals(OpusProvider.OPUS_NAME);
+        isOpusQuad = OpusProvider.isOpusCompatibleDevice(name);
         number = Util.unsign(packetBytes[0x24]);
     }
 
@@ -77,7 +77,7 @@ public class DeviceAnnouncement {
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         timestamp = System.currentTimeMillis();
         name = new String(packetBytes, 0x0c, 20).trim();
-        isOpusQuad = name.equals(OpusProvider.OPUS_NAME);
+        isOpusQuad = OpusProvider.isOpusCompatibleDevice(name);
         number = deviceNumber;
     }
 
@@ -182,7 +182,9 @@ public class DeviceAnnouncement {
     }
 
     /**
-     * Check whether a device update came from an Opus Quad, which behaves very differently from true Pro DJ Link hardware.
+     * Check whether a device update came from hardware that behaves like the Opus Quad,
+     * which includes the XDJ-AZ in four deck mode. These devices behave very
+     * differently from true Pro DJ Link hardware.
      */
     @API(status = API.Status.EXPERIMENTAL)
     public final boolean isOpusQuad;

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
@@ -193,9 +193,10 @@ public class DeviceFinder extends LifecycleParticipant {
     }
 
     /**
-     * Handle a device announcement packet we have received from the Opus Quad.
+     * Handle a device announcement packet we have received from hardware that behaves
+     * like the Opus Quad (including the XDJ-AZ operating in 4 deck mode).
      *
-     * @param packet the packet from Opus Quad to infer the 4 players
+     * @param packet the packet from which to infer the four players
      */
     private void createAndProcessOpusAnnouncements(DatagramPacket packet) {
         for (int i = 1; i <= 4; i++) {

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceUpdate.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceUpdate.java
@@ -66,7 +66,7 @@ public abstract class DeviceUpdate {
         packetBytes = new byte[packet.getLength()];
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         deviceName = new String(packetBytes, 0x0b, 20).trim();
-        isFromOpusQuad = deviceName.equals(OpusProvider.OPUS_NAME);
+        isFromOpusQuad = OpusProvider.isOpusCompatibleDevice(deviceName);
         preNexusCdj = deviceName.startsWith("CDJ") && (deviceName.endsWith("900") || deviceName.endsWith("2000"));
 
         if (isFromOpusQuad) {
@@ -130,7 +130,8 @@ public abstract class DeviceUpdate {
     }
 
     /**
-     * Indicates whether this device update came from an Opus Quad, which behaves very differently from true Pro DJ Link hardware.
+     * Indicates whether this device update came from hardware that behaves like the Opus Quad,
+     * including the XDJ-AZ operating in four deck mode.
      */
     @API(status = API.Status.EXPERIMENTAL)
     public final boolean isFromOpusQuad;

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
@@ -52,16 +52,16 @@ public class VirtualCdj extends LifecycleParticipant {
     private final AtomicReference<DatagramSocket> socket = new AtomicReference<>();
 
     /**
-     * Indicates we started {@link VirtualRekordbox} running, so we are just acting as a proxy for it, to
-     * work with the Opus Quad.
+     * Indicates we started {@link VirtualRekordbox} running, so we are just acting as a proxy for it,
+     * to work with Opus-compatible hardware such as the Opus Quad or the XDJ-AZ.
      */
     private final AtomicBoolean proxyingForVirtualRekordbox = new AtomicBoolean(false);
 
     /**
-     * Check whether we are simply proxying information from {@link VirtualRekordbox} so that we can work with the Opus
-     * Quad rather than real Pro DJ Link hardware.
+     * Check whether we are simply proxying information from {@link VirtualRekordbox} so that we can work with
+     * Opus-compatible devices rather than real Pro DJ Link hardware.
      *
-     * @return an indication that we are in a limited mode to support the Opus Quad.
+     * @return an indication that we are in a limited mode to support Opus-compatible hardware.
      */
     @API(status = API.Status.EXPERIMENTAL)
     public boolean inOpusQuadCompatibilityMode() {
@@ -503,7 +503,7 @@ public class VirtualCdj extends LifecycleParticipant {
      * role from or to another device.</p>
      *
      * <p>This used to be a private method, but it was made package accessible as part of the effort to support
-     * Opus Quad hardware, so {@link VirtualRekordbox} could proxy the status packets it receives through us.</p>
+     * Opus-compatible hardware, so {@link VirtualRekordbox} could proxy the status packets it receives through us.</p>
      */
     void processUpdate(DeviceUpdate update) {
         updates.put(DeviceReference.getDeviceReference(update), update);
@@ -1068,8 +1068,8 @@ public class VirtualCdj extends LifecycleParticipant {
 
     /**
      * <p>In normal operation (with Pro DJ Link devices), start announcing ourselves and listening for status packets.
-     * If, however, we find an Opus Quad on the network, start {@link VirtualRekordbox} and operate in a more
-     * limited Opus Quad compatibility mode, acting as a proxy for packets that it is responsible for receiving.
+     * If, however, we find an Opus-compatible device on the network, start {@link VirtualRekordbox} and operate in a
+     * limited compatibility mode, acting as a proxy for packets that it is responsible for receiving.
      * Either mode requires the {@link DeviceFinder} to be active in order to find out how to communicate with
      * other devices, so will start that if it is not already.</p>
      *
@@ -1102,7 +1102,8 @@ public class VirtualCdj extends LifecycleParticipant {
                 return false;
             }
 
-            // See if there is an Opus Quad on the network, which means we need to be in the limited compatibility mode.
+            // See if there is an Opus-compatible device on the network, which means we
+            // need to be in the limited compatibility mode.
             for (DeviceAnnouncement device : DeviceFinder.getInstance().getCurrentDevices()) {
                 if (device.isOpusQuad) {
                     proxyingForVirtualRekordbox.set(true);
@@ -2169,7 +2170,7 @@ public class VirtualCdj extends LifecycleParticipant {
         if (send) {  // Start sending status packets.
             ensureRunning();
             if (proxyingForVirtualRekordbox.get()) {
-                throw new IllegalStateException("Cannot send status when in Opus Quad compatibility mode.");
+                throw new IllegalStateException("Cannot send status when in Opus compatibility mode.");
             }
             if ((getDeviceNumber() < 1) || (getDeviceNumber() > 4)) {
                 throw new IllegalStateException("Can only send status when using a standard player number, 1 through 4.");

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -49,6 +49,23 @@ public class OpusProvider {
     public static final String OPUS_NAME = "OPUS-QUAD";
 
     /**
+     * The device name reported by the XDJ-AZ when it is operating in 4 deck mode.
+     */
+    public static final String XDJ_AZ_NAME = "XDJ-AZ";
+
+    /**
+     * Check whether a device name corresponds to hardware that behaves like the
+     * Opus Quad and therefore requires Rekordbox lighting compatibility mode.
+     *
+     * @param deviceName the name reported by the hardware
+     * @return {@code true} if this is an Opus compatible device
+     */
+    @API(status = API.Status.EXPERIMENTAL)
+    public static boolean isOpusCompatibleDevice(String deviceName) {
+        return OPUS_NAME.equals(deviceName) || XDJ_AZ_NAME.equals(deviceName);
+    }
+
+    /**
      * Keep track of whether we are running.
      */
     private static final AtomicBoolean running = new AtomicBoolean(false);


### PR DESCRIPTION
## Summary
- handle XDJ-AZ as Opus-compatible hardware
- update README and CHANGELOG
- clarify JavaDocs referencing Opus Quad

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f34cf3388320b3cade8850ef72b7