### PR TITLE
Rename Opus flags

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -683,7 +683,7 @@ public class CdjStatus extends DeviceUpdate {
         handingMasterToDevice = Util.unsign(packetBytes[MASTER_HAND_OFF]);
 
         final byte trackSourceByte = packetBytes[0x28];
-        if (isFromOpusQuad && (trackSourceByte < 16)) {
+        if (isOpusCompatible && (trackSourceByte < 16)) {
             // sourcePlayer variable will be changed to the slot number, it's not the deck number
             int sourcePlayer = Util.translateOpusPlayerNumbers(trackSourceByte);
             int player = Util.translateOpusPlayerNumbers(trackSourceByte);

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
@@ -56,7 +56,7 @@ public class DeviceAnnouncement {
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         timestamp = System.currentTimeMillis();
         name = new String(packetBytes, 0x0c, 20).trim();
-        isOpusQuad = OpusProvider.isOpusCompatibleDevice(name);
+        isOpusCompatible = OpusProvider.isOpusCompatibleDevice(name);
         number = Util.unsign(packetBytes[0x24]);
     }
 
@@ -77,7 +77,7 @@ public class DeviceAnnouncement {
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         timestamp = System.currentTimeMillis();
         name = new String(packetBytes, 0x0c, 20).trim();
-        isOpusQuad = OpusProvider.isOpusCompatibleDevice(name);
+        isOpusCompatible = OpusProvider.isOpusCompatibleDevice(name);
         number = deviceNumber;
     }
 
@@ -182,12 +182,12 @@ public class DeviceAnnouncement {
     }
 
     /**
-     * Check whether a device update came from hardware that behaves like the Opus Quad,
+     * Check whether this announcement came from hardware that behaves like the Opus Quad,
      * which includes the XDJ-AZ in four deck mode. These devices behave very
      * differently from true Pro DJ Link hardware.
      */
     @API(status = API.Status.EXPERIMENTAL)
-    public final boolean isOpusQuad;
+    public final boolean isOpusCompatible;
 
     @Override
     public String toString() {

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
@@ -266,7 +266,7 @@ public class DeviceFinder extends LifecycleParticipant {
 
                                     DeviceAnnouncement announcement = new DeviceAnnouncement(packet);
 
-                                    if (announcement.isOpusQuad) {
+                                    if (announcement.isOpusCompatible) {
                                         createAndProcessOpusAnnouncements(packet);
                                     } else {
                                         processAnnouncement(announcement);

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceUpdate.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceUpdate.java
@@ -66,10 +66,10 @@ public abstract class DeviceUpdate {
         packetBytes = new byte[packet.getLength()];
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         deviceName = new String(packetBytes, 0x0b, 20).trim();
-        isFromOpusQuad = OpusProvider.isOpusCompatibleDevice(deviceName);
+        isOpusCompatible = OpusProvider.isOpusCompatibleDevice(deviceName);
         preNexusCdj = deviceName.startsWith("CDJ") && (deviceName.endsWith("900") || deviceName.endsWith("2000"));
 
-        if (isFromOpusQuad) {
+        if (isOpusCompatible) {
             deviceNumber = Util.translateOpusPlayerNumbers(packetBytes[DEVICE_NUMBER_OFFSET]);
         } else {
             deviceNumber = Util.unsign(packetBytes[DEVICE_NUMBER_OFFSET]);
@@ -130,11 +130,11 @@ public abstract class DeviceUpdate {
     }
 
     /**
-     * Indicates whether this device update came from hardware that behaves like the Opus Quad,
-     * including the XDJ-AZ operating in four deck mode.
+     * Indicates whether this device update came from hardware that is Opus compatible,
+     * such as the Opus Quad or the XDJ-AZ operating in four deck mode.
      */
     @API(status = API.Status.EXPERIMENTAL)
-    public final boolean isFromOpusQuad;
+    public final boolean isOpusCompatible;
 
     /**
      * Get the raw data bytes of the device update packet.

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
@@ -1105,7 +1105,7 @@ public class VirtualCdj extends LifecycleParticipant {
             // See if there is an Opus-compatible device on the network, which means we
             // need to be in the limited compatibility mode.
             for (DeviceAnnouncement device : DeviceFinder.getInstance().getCurrentDevices()) {
-                if (device.isOpusQuad) {
+                if (device.isOpusCompatible) {
                     proxyingForVirtualRekordbox.set(true);
                     VirtualRekordbox.getInstance().addLifecycleListener(virtualRekordboxLifecycleListener);
                     final boolean success = VirtualRekordbox.getInstance().start();


### PR DESCRIPTION
## Summary
- rename `isOpusQuad` fields to `isOpusCompatible`
- update constructors and usages
- adjust javadocs to reflect new flag name

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848033f7cbc8320bb22f93015db988b