### PR TITLE
Fix SlotReference null handling

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -263,7 +263,7 @@ public class OpusProvider {
         final RekordboxUsbArchive formerArchive = usbArchiveMap.remove(usbSlotNumber);
 
         // Report archive closed.
-        final SlotReference emptySlotReference = SlotReference.getSlotReference(usbSlotNumber, null);
+        final SlotReference emptySlotReference = SlotReference.getSlotReference(usbSlotNumber, CdjStatus.TrackSourceSlot.NO_TRACK);
         final MediaDetails emptyDetails = new MediaDetails(emptySlotReference, CdjStatus.TrackType.REKORDBOX, "",
                 0, 0, 0);
 

--- a/src/main/java/org/deepsymmetry/beatlink/data/SlotReference.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/SlotReference.java
@@ -43,6 +43,7 @@ public class SlotReference {
      * @throws NullPointerException if {@code slot} is {@code null}
      */
     private SlotReference(int player, CdjStatus.TrackSourceSlot slot) {
+        Objects.requireNonNull(slot, "slot");
         this.player = player;
         this.slot = slot;
         hashcode = Objects.hash(player, slot);
@@ -65,6 +66,7 @@ public class SlotReference {
      */
     @API(status = API.Status.STABLE)
     public static synchronized SlotReference getSlotReference(int player, CdjStatus.TrackSourceSlot slot) {
+        Objects.requireNonNull(slot, "slot");
         Map<CdjStatus.TrackSourceSlot, SlotReference> playerMap = instances.computeIfAbsent(player, k -> new HashMap<>());
         return playerMap.computeIfAbsent(slot, s -> new SlotReference(player, s));
     }

--- a/src/test/java/org/deepsymmetry/beatlink/data/SlotReferenceTest.java
+++ b/src/test/java/org/deepsymmetry/beatlink/data/SlotReferenceTest.java
@@ -1,0 +1,11 @@
+package org.deepsymmetry.beatlink.data;
+
+import org.deepsymmetry.beatlink.CdjStatus;
+import org.junit.Test;
+
+public class SlotReferenceTest {
+    @Test(expected = NullPointerException.class)
+    public void getSlotReferenceRejectsNullSlot() {
+        SlotReference.getSlotReference(1, null);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce non-null slot parameter in `SlotReference`
- avoid passing null in `OpusProvider.attachMetadataArchive`
- test NullPointerException for null slot

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68482f701c7c83209b54db3effb4bf63