### PR TITLE
Clarify SlotReference semantics for Opus devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ In addition to learning about what is happening on other players, the
 tell them to load a track from any media currently mounted in a player
 by calling
 [`sendLoadTrackCommand()`](https://deepsymmetry.org/beatlink/apidocs/org/deepsymmetry/beatlink/VirtualCdj.html#sendLoadTrackCommand-int-int-int-org.deepsymmetry.beatlink.CdjStatus.TrackSourceSlot-org.deepsymmetry.beatlink.CdjStatus.TrackType-).
+When working with an Opus-compatible device, the third argument to this
+method is the USB slot number to load from rather than a player number.
 You can cause them to start playing (if they are currently at the cue
 position), or stop playing and return to the cue position, by calling
 [`sendFaderStartCommand()`](https://deepsymmetry.org/beatlink/apidocs/org/deepsymmetry/beatlink/VirtualCdj.html#sendFaderStartCommand-java.util.Set-java.util.Set-).
@@ -281,6 +283,8 @@ quickly be overridden by the next one sent by the DJM.)
 You can ask the `VirtualCdj` to find out details about the media
 mounted in a player's media slot by calling
 [`sendMediaQuery()`](https://deepsymmetry.org/beatlink/apidocs/org/deepsymmetry/beatlink/VirtualCdj.html#sendMediaQuery-org.deepsymmetry.beatlink.data.SlotReference-).
+When talking to Opus-compatible devices, the `player` value of a
+`SlotReference` actually represents the USB slot number on that device.
 In order to receive the response, you have to previously have
 registered a
 [`MediaDetailsListener`](https://deepsymmetry.org/beatlink/apidocs/org/deepsymmetry/beatlink/MediaDetailsListener.html)
@@ -439,6 +443,8 @@ about any mounted media database by calling
 [`getMountedMediaDetails()`](https://deepsymmetry.org/beatlink/apidocs/org/deepsymmetry/beatlink/data/MetadataFinder.html#getMountedMediaDetails--)
 or
 [`getMediaDetailsFor()`](https://deepsymmetry.org/beatlink/apidocs/org/deepsymmetry/beatlink/data/MetadataFinder.html#getMediaDetailsFor-org.deepsymmetry.beatlink.data.SlotReference-).
+Remember that on Opus-compatible devices the `player` field of a
+`SlotReference` is the USB slot number.
 
 ### Loading Menus
 

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -684,18 +684,18 @@ public class CdjStatus extends DeviceUpdate {
 
         final byte trackSourceByte = packetBytes[0x28];
         if (isOpusCompatible && (trackSourceByte < 16)) {
-            // sourcePlayer variable will be changed to the slot number, it's not the deck number
-            int sourcePlayer = Util.translateOpusPlayerNumbers(trackSourceByte);
+            // translate the track source byte into the USB slot number, not a deck number
+            int usbSlotNumber = Util.translateOpusPlayerNumbers(trackSourceByte);
             int player = Util.translateOpusPlayerNumbers(trackSourceByte);
-            if (sourcePlayer != 0) {
+            if (usbSlotNumber != 0) {
                 final SlotReference matchedSourceSlot = VirtualRekordbox.getInstance().findMatchedTrackSourceSlotForPlayer(deviceNumber);
                 if (matchedSourceSlot != null) {
-                    sourcePlayer = matchedSourceSlot.player;
+                    usbSlotNumber = matchedSourceSlot.player;
                 }
                 final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
                 maybeRekordboxId = deviceSqlRekordboxId;
             }
-            trackSourcePlayer = sourcePlayer;
+            trackSourcePlayer = usbSlotNumber;
             trackSourceSlot = TrackSourceSlot.USB_SLOT;
             // Indicate whether we have a metadata archive available for the USB slot:
             packetBytes[LOCAL_USB_STATE] = (byte) (OpusProvider.getInstance().findArchive(deviceNumber) == null? 4 : 0);

--- a/src/main/java/org/deepsymmetry/beatlink/data/SlotReference.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/SlotReference.java
@@ -11,6 +11,11 @@ import java.util.Objects;
  * Uniquely identifies a media slot on the network from which tracks can be loaded, by the player and slot type.
  * A simple immutable value class, with the property that all instances are interned, such that any instances with
  * the same value will actually be the same object, for fast comparison.
+ * <p>
+ * When communicating with an Opus-compatible device such as the Opus&nbsp;Quad,
+ * the {@code player} value actually represents the USB slot number rather than
+ * a deck number.
+ * </p>
  *
  * @author James Elliott
  */
@@ -18,7 +23,8 @@ import java.util.Objects;
 public class SlotReference {
 
     /**
-     * The player in which this slot is found.
+     * The player in which this slot is found. When interacting with
+     * Opus-compatible devices, this represents the USB slot number.
      */
     @API(status = API.Status.STABLE)
     public final int player;
@@ -37,7 +43,8 @@ public class SlotReference {
     /**
      * Create a unique reference to a media slot on the network from which tracks can be loaded.
      *
-     * @param player the player in which the slot is found
+     * @param player the player in which the slot is found. For Opus-compatible
+     *               devices this is the USB slot number.
      * @param slot the specific type of the slot
      *
      * @throws NullPointerException if {@code slot} is {@code null}
@@ -56,7 +63,8 @@ public class SlotReference {
     /**
      * Get a unique reference to a media slot on the network from which tracks can be loaded.
      *
-     * @param player the player in which the slot is found
+     * @param player the player in which the slot is found. For Opus-compatible
+     *               devices this is the USB slot number.
      * @param slot the specific type of the slot
      *
      * @return the instance that will always represent the specified slot


### PR DESCRIPTION
## Summary
- clarify that SlotReference.player is a USB slot on Opus devices
- rename sourcePlayer parameter to sourceUsbSlot
- update docs and comments to reflect USB slot semantics

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482f71b8448320a885491d2734d269