### PR TITLE
Fix track mapping on XDJ‑AZ players

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -686,13 +686,12 @@ public class CdjStatus extends DeviceUpdate {
         if (isOpusCompatible && (trackSourceByte < 16)) {
             // sourcePlayer variable will be changed to the slot number, it's not the deck number
             int sourcePlayer = Util.translateOpusPlayerNumbers(trackSourceByte);
-            int player = Util.translateOpusPlayerNumbers(trackSourceByte);
             if (sourcePlayer != 0) {
                 final SlotReference matchedSourceSlot = VirtualRekordbox.getInstance().findMatchedTrackSourceSlotForPlayer(deviceNumber);
                 if (matchedSourceSlot != null) {
                     sourcePlayer = matchedSourceSlot.player;
                 }
-                final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
+                final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(deviceNumber);
                 maybeRekordboxId = deviceSqlRekordboxId;
             }
             trackSourcePlayer = sourcePlayer;


### PR DESCRIPTION
## Summary
- correct Rekordbox ID lookup for Opus-compatible players

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684842a14ac08320be1824bb1ee25a99